### PR TITLE
fix!: restrict paste downloads to PasteBin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.1.7
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Read only: **True**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**paste_url** | required | PasteBin URL to fetch the data | string | `url` |
+**paste_url** | required | HTTPS PasteBin paste URL (for example, https://pastebin.com/AbCd1234) | string | `url` |
 
 #### Action Output
 

--- a/pastebin.json
+++ b/pastebin.json
@@ -58,7 +58,7 @@
             "read_only": true,
             "parameters": {
                 "paste_url": {
-                    "description": "PasteBin URL to fetch the data",
+                    "description": "HTTPS PasteBin paste URL (for example, https://pastebin.com/AbCd1234)",
                     "data_type": "string",
                     "contains": [
                         "url"

--- a/pastebin_connector.py
+++ b/pastebin_connector.py
@@ -325,9 +325,7 @@ class PasteBinConnector(BaseConnector):
     def _get_paste_data(self, action_result, pasteid):
         url = (GET_PASTE_DATA_URL).format(pasteid)
 
-        ret_val, response = self._make_rest_call(
-            url=url, action_result=action_result, timeout=30, method="get", allow_redirects=False
-        )
+        ret_val, response = self._make_rest_call(url=url, action_result=action_result, timeout=30, method="get", allow_redirects=False)
         if phantom.is_fail(ret_val):
             return action_result.get_status(), None
 
@@ -363,9 +361,7 @@ class PasteBinConnector(BaseConnector):
 
         try:
             self.save_progress(f"Fetching paste with ID {pasteid}")
-            ret_val, response = self._make_rest_call(
-                url=url, action_result=action_result, timeout=30, method="get", allow_redirects=False
-            )
+            ret_val, response = self._make_rest_call(url=url, action_result=action_result, timeout=30, method="get", allow_redirects=False)
             if phantom.is_fail(ret_val):
                 return action_result.get_status()
 

--- a/pastebin_connector.py
+++ b/pastebin_connector.py
@@ -15,6 +15,7 @@
 #
 #
 # Python 3 Compatibility imports
+import re
 import traceback
 import urllib.parse
 from urllib.parse import urlparse
@@ -161,7 +162,7 @@ class PasteBinConnector(BaseConnector):
         # store the r_text in debug data, it will get dumped in the logs if the action fails
         if hasattr(action_result, "add_debug_data"):
             action_result.add_debug_data({"r_status_code": r.status_code})
-            action_result.add_debug_data({"r_text": r.text})
+            action_result.add_debug_data({"r_text": r.text[:PASTEBIN_DEBUG_RESPONSE_LENGTH]})
             action_result.add_debug_data({"r_headers": r.headers})
 
         if "html" in r.headers.get("Content-Type", ""):
@@ -173,9 +174,7 @@ class PasteBinConnector(BaseConnector):
         if not r.text:
             return self._process_empty_response(r, action_result)
 
-        message = "Can't process response from server. Status Code: {} Data from server: {}".format(
-            r.status_code, r.text.replace("{", "{{").replace("}", "}}")
-        )
+        message = f"Can't process response from server. Status Code: {r.status_code}"
 
         return RetVal(action_result.set_status(phantom.APP_ERROR, message), None)
 
@@ -326,7 +325,9 @@ class PasteBinConnector(BaseConnector):
     def _get_paste_data(self, action_result, pasteid):
         url = (GET_PASTE_DATA_URL).format(pasteid)
 
-        ret_val, response = self._make_rest_call(url=url, action_result=action_result, timeout=30, method="get")
+        ret_val, response = self._make_rest_call(
+            url=url, action_result=action_result, timeout=30, method="get", allow_redirects=False
+        )
         if phantom.is_fail(ret_val):
             return action_result.get_status(), None
 
@@ -337,9 +338,23 @@ class PasteBinConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
         container_id = self.get_container_id()
 
-        url = param["paste_url"]
         try:
-            pasteid = urlparse(url).path.strip("/")
+            parsed_url = urlparse(param["paste_url"])
+            path_parts = [part for part in parsed_url.path.split("/") if part]
+            if (
+                parsed_url.scheme.lower() != "https"
+                or parsed_url.hostname != PASTEBIN_HOST
+                or parsed_url.port not in (None, 443)
+                or parsed_url.username is not None
+                or parsed_url.password is not None
+                or parsed_url.query
+                or parsed_url.fragment
+                or len(path_parts) != 1
+                or not re.fullmatch(PASTEBIN_ID_PATTERN, path_parts[0])
+            ):
+                raise ValueError("URL must be an HTTPS PasteBin paste URL")
+            pasteid = path_parts[0]
+            url = PASTEBIN_PASTE_URL.format(pasteid)
         except Exception as e:
             error_msg = (
                 f"Unable to get paste id from the URL. Please provide valid 'paste url' parameter. {self._get_error_message_from_exception(e)}"
@@ -348,7 +363,9 @@ class PasteBinConnector(BaseConnector):
 
         try:
             self.save_progress(f"Fetching paste with ID {pasteid}")
-            ret_val, response = self._make_rest_call(url=url, action_result=action_result, timeout=30, method="get")
+            ret_val, response = self._make_rest_call(
+                url=url, action_result=action_result, timeout=30, method="get", allow_redirects=False
+            )
             if phantom.is_fail(ret_val):
                 return action_result.get_status()
 

--- a/pastebin_consts.py
+++ b/pastebin_consts.py
@@ -31,6 +31,10 @@ GET_USER_KEY_URL = "https://pastebin.com/api/api_login.php"
 PASTEBIN_GET_USER_KEY_PAYLOAD = "api_dev_key={}&api_user_name={}&api_user_password={}"
 # Get paste data
 GET_PASTE_DATA_URL = "https://pastebin.com/raw/{}"
+PASTEBIN_HOST = "pastebin.com"
+PASTEBIN_PASTE_URL = "https://pastebin.com/{}"
+PASTEBIN_ID_PATTERN = r"[A-Za-z0-9]{1,32}"
+PASTEBIN_DEBUG_RESPONSE_LENGTH = 1024
 # Error messages
 PASTEBIN_ERROR_MESSAGE = "Unknown error occurred. Please check the asset configuration and|or action parameters"
 PASTEBIN_ERROR_CODE_MESSAGE = "Error code unavailable"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Chore: prepare connector security remediation.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Chore: prepare connector security remediation.
+* Restrict paste downloads to validated HTTPS PasteBin URLs, disable redirects, and omit unexpected response bodies from errors. [PSAAS-30643]


### PR DESCRIPTION
## Summary

- require caller-supplied paste URLs to use HTTPS and the exact PasteBin host
- validate paste identifiers and reconstruct requests against fixed PasteBin endpoints
- disable redirects for paste page and raw-data downloads
- omit unexpected response bodies from action errors and bound debug previews
- adopt dev-cicd-tools v2.1.7

## Tracking

- Epic: ESPM-5228
- PAPP: PAPP-38006
- PSAAS-30643

## Validation

- full non-package pre-commit suite passed under Python 3.13
- Docker-backed dependency packaging passed separately
- SOAR App Linter, Semgrep, static tests, and Python compilation passed
- all commits are signed

Authored by Codex.

## Tracking

- PAPP: PAPP-38006
- PSAAS: PSAAS-30643
- Written by Codex.