### PR TITLE
fix: make PasteBin connectivity read-only and bound downloads

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.7
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Publisher: Splunk <br>
 Connector Version: 3.0.0 <br>
 Product Vendor: PasteBin <br>
 Product Name: PasteBin <br>
-Minimum Product Version: 6.1.1
+Minimum Product Version: 6.3.0
 
 This app integrates with PasteBin to perform investigative and generic actions
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Pastebin password.
   To download, parse, and save a paste from PasteBin, the user can run this action. After a
   successful run of the action, the text file will be generated with paste data and stored in the
   vault.\
+  Paste pages and raw paste data are limited to 10 MiB per response.
   [![](img/get_data_details.png)](img/get_data_details.png)
 
   - **Action Parameter** : Pastebin URL

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ Follow these steps to configure the PasteBin Splunk SOAR app's asset:
   - Navigate to the **Asset Info** tab and enter the Asset name and Asset description.
   - Navigate to the **Asset Settings** .
   - Paste the generated **API Key** from PasteBin UI to its respective configuration parameter.
-  - Pastebin username and password are optional parameters. To create any paste as user, you
-    need to provide credentials for the same.
+  - Pastebin username and password are optional for actions that do not authenticate a user. They
+    are required to create a paste as a user and to run test connectivity.
   - Save the asset.
   - Now, test the connectivity of the Splunk SOAR server to the PasteBin instance by clicking
-    the **TEST CONNECTIVITY** button.
+    the **TEST CONNECTIVITY** button. The test validates the configured credentials through
+    PasteBin's read-only login endpoint without creating a paste.
 
 ## Explanation of the Asset Configuration Parameters
 
@@ -53,6 +54,7 @@ Pastebin password.
 - **Pastebin api dev key (Required):** API Token for asset authorization.
 - **Pastebin username (Optional):** The username of your PasteBin account.
 - **Pastebin password (Optional):** The password of your PasteBin account.
+- **Test connectivity:** Username and password are required for this action.
 - NOTE: The developer API key, username, and password, all must belong to one particular account
   to create paste as a user.
 
@@ -60,8 +62,8 @@ Pastebin password.
 
 - ### Test Connectivity (Action Workflow Details)
 
-  - This action will test the connectivity of the Splunk SOAR server to the PasteBin instance by
-    making an initial API call using the provided asset configuration parameters.
+  - This action validates the developer key, username, and password through PasteBin's read-only
+    login endpoint and does not create a paste.
   - The action validates the provided asset configuration parameters. Based on the API call
     response, the appropriate success and failure message will be displayed when the action gets
     executed.
@@ -135,13 +137,13 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using the supplied configuration <br>
+[test connectivity](#action-test-connectivity) - Validate the developer key, username, and password using PasteBin's read-only login endpoint <br>
 [get data](#action-get-data) - Download, parse, and save a paste from PasteBin <br>
 [create paste](#action-create-paste) - Create a paste from PasteBin
 
 ## action: 'test connectivity'
 
-Validate the asset configuration for connectivity using the supplied configuration
+Validate the developer key, username, and password using PasteBin's read-only login endpoint
 
 Type: **test** <br>
 Read only: **True**

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -63,6 +63,7 @@ Pastebin password.
   To download, parse, and save a paste from PasteBin, the user can run this action. After a
   successful run of the action, the text file will be generated with paste data and stored in the
   vault.\
+  Paste pages and raw paste data are limited to 10 MiB per response.
   [![](img/get_data_details.png)](img/get_data_details.png)
 
   - **Action Parameter** : Pastebin URL

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -28,11 +28,12 @@ Follow these steps to configure the PasteBin Splunk SOAR app's asset:
   - Navigate to the **Asset Info** tab and enter the Asset name and Asset description.
   - Navigate to the **Asset Settings** .
   - Paste the generated **API Key** from PasteBin UI to its respective configuration parameter.
-  - Pastebin username and password are optional parameters. To create any paste as user, you
-    need to provide credentials for the same.
+  - Pastebin username and password are optional for actions that do not authenticate a user. They
+    are required to create a paste as a user and to run test connectivity.
   - Save the asset.
   - Now, test the connectivity of the Splunk SOAR server to the PasteBin instance by clicking
-    the **TEST CONNECTIVITY** button.
+    the **TEST CONNECTIVITY** button. The test validates the configured credentials through
+    PasteBin's read-only login endpoint without creating a paste.
 
 ## Explanation of the Asset Configuration Parameters
 
@@ -43,6 +44,7 @@ Pastebin password.
 - **Pastebin api dev key (Required):** API Token for asset authorization.
 - **Pastebin username (Optional):** The username of your PasteBin account.
 - **Pastebin password (Optional):** The password of your PasteBin account.
+- **Test connectivity:** Username and password are required for this action.
 - NOTE: The developer API key, username, and password, all must belong to one particular account
   to create paste as a user.
 
@@ -50,8 +52,8 @@ Pastebin password.
 
 - ### Test Connectivity (Action Workflow Details)
 
-  - This action will test the connectivity of the Splunk SOAR server to the PasteBin instance by
-    making an initial API call using the provided asset configuration parameters.
+  - This action validates the developer key, username, and password through PasteBin's read-only
+    login endpoint and does not create a paste.
   - The action validates the provided asset configuration parameters. Based on the API call
     response, the appropriate success and failure message will be displayed when the action gets
     executed.

--- a/pastebin.json
+++ b/pastebin.json
@@ -12,7 +12,7 @@
     "product_vendor": "PasteBin",
     "product_name": "PasteBin",
     "product_version_regex": ".*",
-    "min_phantom_version": "6.1.1",
+    "min_phantom_version": "6.3.0",
     "app_wizard_version": "1.0.0",
     "python_version": "3.9, 3.13",
     "logo": "logo_pastebin.svg",

--- a/pastebin.json
+++ b/pastebin.json
@@ -43,7 +43,7 @@
         {
             "action": "test connectivity",
             "identifier": "test_connectivity",
-            "description": "Validate the asset configuration for connectivity using the supplied configuration",
+            "description": "Validate the developer key, username, and password using PasteBin's read-only login endpoint",
             "type": "test",
             "read_only": true,
             "parameters": {},

--- a/pastebin_connector.py
+++ b/pastebin_connector.py
@@ -199,6 +199,50 @@ class PasteBinConnector(BaseConnector):
 
         return self._process_response(requests_response, action_result)
 
+    def _get_bounded_text(self, url, action_result):
+        try:
+            with requests.get(
+                url,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+                allow_redirects=False,
+                stream=True,
+            ) as response:
+                if not (200 <= response.status_code < 300):
+                    return RetVal(
+                        action_result.set_status(
+                            phantom.APP_ERROR,
+                            f"PasteBin returned HTTP status {response.status_code}",
+                        ),
+                        None,
+                    )
+
+                content_length = response.headers.get("Content-Length")
+                if content_length:
+                    try:
+                        if int(content_length) > PASTEBIN_MAX_DOWNLOAD_BYTES:
+                            return RetVal(action_result.set_status(phantom.APP_ERROR, PASTEBIN_DOWNLOAD_TOO_LARGE_MESSAGE), None)
+                    except ValueError:
+                        self.debug_print("PasteBin returned an invalid Content-Length header")
+
+                response_bytes = bytearray()
+                for chunk in response.iter_content(chunk_size=PASTEBIN_DOWNLOAD_CHUNK_SIZE):
+                    if not chunk:
+                        continue
+                    if len(response_bytes) + len(chunk) > PASTEBIN_MAX_DOWNLOAD_BYTES:
+                        return RetVal(action_result.set_status(phantom.APP_ERROR, PASTEBIN_DOWNLOAD_TOO_LARGE_MESSAGE), None)
+                    response_bytes.extend(chunk)
+
+                encoding = response.encoding or "utf-8"
+                return RetVal(phantom.APP_SUCCESS, response_bytes.decode(encoding, errors="replace"))
+        except Exception as e:
+            return RetVal(
+                action_result.set_status(
+                    phantom.APP_ERROR,
+                    f"Error connecting to server. Details: {self._get_error_message_from_exception(e)}",
+                ),
+                None,
+            )
+
     def _handle_test_connectivity(self, param):
         # Add an action result object to self (BaseConnector) to represent the action for this param
         action_result = self.add_action_result(ActionResult(dict(param)))
@@ -329,7 +373,7 @@ class PasteBinConnector(BaseConnector):
     def _get_paste_data(self, action_result, pasteid):
         url = (GET_PASTE_DATA_URL).format(pasteid)
 
-        ret_val, response = self._make_rest_call(url=url, action_result=action_result, timeout=30, method="get", allow_redirects=False)
+        ret_val, response = self._get_bounded_text(url, action_result)
         if phantom.is_fail(ret_val):
             return action_result.get_status(), None
 
@@ -365,7 +409,7 @@ class PasteBinConnector(BaseConnector):
 
         try:
             self.save_progress(f"Fetching paste with ID {pasteid}")
-            ret_val, response = self._make_rest_call(url=url, action_result=action_result, timeout=30, method="get", allow_redirects=False)
+            ret_val, response = self._get_bounded_text(url, action_result)
             if phantom.is_fail(ret_val):
                 return action_result.get_status()
 

--- a/pastebin_connector.py
+++ b/pastebin_connector.py
@@ -204,9 +204,13 @@ class PasteBinConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
         self.save_progress(PASTEBIN_CONNECTION_MESSAGE)
 
-        api_paste_code = "Test connectivity checked"
+        if not self._pastebin_username or not self._pastebin_password:
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                "Pastebin username and password are required for the read-only connectivity test",
+            )
 
-        ret_val, _ = self._creating_paste(action_result, self._api_key, api_paste_code)
+        ret_val, _ = self._get_user_key(action_result, self._pastebin_username, self._pastebin_password)
         if phantom.is_fail(ret_val):
             self.save_progress(PASTEBIN_CONNECTIVITY_FAIL_MESSAGE)
             return action_result.get_status()

--- a/pastebin_consts.py
+++ b/pastebin_consts.py
@@ -35,6 +35,9 @@ PASTEBIN_HOST = "pastebin.com"
 PASTEBIN_PASTE_URL = "https://pastebin.com/{}"
 PASTEBIN_ID_PATTERN = r"[A-Za-z0-9]{1,32}"
 PASTEBIN_DEBUG_RESPONSE_LENGTH = 1024
+PASTEBIN_MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024
+PASTEBIN_DOWNLOAD_CHUNK_SIZE = 64 * 1024
+PASTEBIN_DOWNLOAD_TOO_LARGE_MESSAGE = "PasteBin response exceeds the 10 MiB download limit"
 # Error messages
 PASTEBIN_ERROR_MESSAGE = "Unknown error occurred. Please check the asset configuration and|or action parameters"
 PASTEBIN_ERROR_CODE_MESSAGE = "Error code unavailable"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Refresh development validation tooling. [PSAAS-32772]
+* Make test connectivity read-only by validating the required username and password through PasteBin's login endpoint without creating a paste. [PSAAS-32772]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Refresh development validation tooling. [PSAAS-32772]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Make test connectivity read-only by validating the required username and password through PasteBin's login endpoint without creating a paste. [PSAAS-32772]
+* Limit PasteBin page and raw-data downloads to 10 MiB while reading responses incrementally. [PSAAS-33444]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Make test connectivity read-only by validating the required username and password through PasteBin's login endpoint without creating a paste. [PSAAS-32772]
 * Limit PasteBin page and raw-data downloads to 10 MiB while reading responses incrementally. [PSAAS-33444]
+* Raise the minimum supported Splunk SOAR version to 6.3.0.


### PR DESCRIPTION
Written by Codex.

## Summary

- make test connectivity read-only by requiring the configured username and password and validating them through PasteBin's login endpoint without creating a paste
- stream PasteBin page and raw-data responses incrementally and reject either response above 10 MiB
- avoid including rejected response bodies in the new bounded-download error path
- raise the minimum supported Splunk SOAR version to 6.3.0
- refresh connector validation hooks to dev-cicd-tools v2.2.8

## Tracking

- Epic: ESPM-5228
- PAPP: PAPP-38281
- PSAAS-32772
- PSAAS-33444

## Validation

- full local pre-commit suite passed, including Docker-backed dependency packaging
- Python 3 syntax compilation passed
- all commits are signed

## Breaking changes

- test connectivity now requires PasteBin username and password; those fields remain optional for actions that do not authenticate a PasteBin user
- Splunk SOAR versions older than 6.3.0 are no longer supported
